### PR TITLE
Support Apply/cancel Enlarged printing of 2D barcode command

### DIFF
--- a/examples/AS-289R2/AS-289R2.ino
+++ b/examples/AS-289R2/AS-289R2.ino
@@ -124,8 +124,14 @@ void AS289R2_demo()
 
   /* QR code */
   char url[] = "https://www.nada.co.jp/as289r2/";
+  tp.setEnlargedQRCode();
   tp.printQRCode(AS289R2::QR_ERR_LVL_M, url);
   tp.print("\r");
+
+  tp.clearEnlargedQRCode();
+  tp.printQRCode(AS289R2::QR_ERR_LVL_M, url);
+  tp.print("\r");
+
   //tp.printf(url);
 
   tp.putLineFeed(2);

--- a/src/AS289R2.cpp
+++ b/src/AS289R2.cpp
@@ -100,6 +100,18 @@ void AS289R2::printQRCode(uint8_t err, const char *param)
     }
 }
 
+void AS289R2::setEnlargedQRCode()
+{
+	byte buffer[3] = {0x1D, 0x79, 0x31};
+	serial.write(buffer, 3);
+}
+
+void AS289R2::clearEnlargedQRCode()
+{
+	byte buffer[3] = {0x1D, 0x79, 0x30};
+	serial.write(buffer, 3);
+}
+
 void AS289R2::printBarCode(uint8_t code, const char *param)
 {
   uint8_t len = strlen(param);

--- a/src/AS289R2.h
+++ b/src/AS289R2.h
@@ -62,15 +62,19 @@ class AS289R2 : public Print
     // Cancel double-width printing
     void clearDoubleSizeWidth(void);
     // Apply LargeFont
-    void setLargeFont(void);
+    void setLargeFont();
     // Cancel LargeFont
-    void clearLargeFont(void);
+    void clearLargeFont();
     // Specify ANK character font
     void setANKFont(uint8_t font);
     // Specify Kanji font
     void setKanjiFont(uint8_t font);
     // Print QR Barcode
     void printQRCode(uint8_t err, const char* param);
+    // Apply EnlargedQRCode
+    void setEnlargedQRCode(void);
+    // Clear EnlargedQRCode
+    void clearEnlargedQRCode(void);
     // Print Barcode
     void printBarCode(uint8_t code, const char* param);
     // Print Bitmap image


### PR DESCRIPTION
Add implementation of `Apply/cancel Enlarged printing of 2D barcode` command.

```cpp
    // Apply EnlargedQRCode
    void setEnlargedQRCode(void);
    // Clear EnlargedQRCode
    void clearEnlargedQRCode(void);
```

![img_3220](https://user-images.githubusercontent.com/855724/28954419-2413a02e-791a-11e7-8c49-e892808dac2a.JPG)

